### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/HtmlToMarkdown.php
+++ b/src/HtmlToMarkdown.php
@@ -31,7 +31,7 @@ class HtmlToMarkdown extends Plugin
         self::$plugin = $this;
         $this->name = $this->getName();
 
-        Craft::$app->view->twig->addExtension(new HtmlToMdTwigExtension);
+        Craft::$app->view->registerTwigExtension(new HtmlToMdTwigExtension);
     }
 
     /**


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.